### PR TITLE
Add space between subclasses, children styles

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,6 +1,7 @@
 {
   "rules": {
     "space-before-function-paren": [2, { "named": "never" }],
+    "space-after-keywords":        [2, "always"],
     "no-shadow-restricted-names":  [2],
     "computed-property-spacing":   [2],
     "no-empty-character-class":    [2],

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+# Autodetect text files
+* text=auto
+
+# Force the following filetypes to have unix eols, so Windows does not break them
+*.* text eol=lf

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ npm-debug.log
 test/**/*.actual.css
 test/**/*.actual.scss
 dev/
+.idea/

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ $ npm install postcss-sorting
 
 ## Options
 
-Currently, there is only one option.
+Currently, there is only two options.
 
 ### `sort-order`
 
@@ -238,6 +238,50 @@ everything would go into five groups: variables, then group with `position`, the
 * `yandex`
 
 Example: `{ "sort-order": "zen" }`
+
+### `empty-lines-between-children-rules`
+
+Set number of empty lines between nested children rules. By default there is no empty lines between '>child' rules.
+
+Acceptable value: `{Number}` of empty lines
+
+Example: `{ "empty-lines-between-children-rules": 1, "sort-order": [ ["..."], [">child"] ] }`
+
+```scss
+/* before */
+.block {
+    position: absolute;
+
+    span {
+        display: inline-block;
+    }
+
+
+    &__element {
+        display: none;
+    }
+    &:hover {
+        top: 0;
+    }
+}
+
+/* after */
+.block {
+    position: absolute;
+
+    span {
+        display: inline-block;
+    }
+
+    &__element {
+        display: none;
+    }
+
+    &:hover {
+        top: 0;
+    }
+}
+```
 
 ## Usage
 

--- a/package.json
+++ b/package.json
@@ -27,6 +27,6 @@
   "scripts": {
     "test": "ava && eslint index.js test/test.js",
     "test2": "ava",
-    "lint": "eslint index.js test/test.js"
+    "lint": "eslint index.js test/test.js --fix"
   }
 }

--- a/test/fixtures/lines-between-children.css
+++ b/test/fixtures/lines-between-children.css
@@ -1,0 +1,29 @@
+.platform-organize {
+    background-image: linear-gradient(-45deg, #ff83b2 0%, #da82d8 49%, #b480ff 100%);
+    &__row {
+        display: flex;
+        &:nth-child(2) {
+            flex-direction: row-reverse;
+        }
+        &:nth-child(3) {
+
+            &:hover {
+                margin-bottom: 50px;
+            }
+        }
+    }
+
+
+
+
+
+    &__row:nth-child(3) &__text {
+        padding-right: 80px;
+        @media (--platform-organize--lap) {
+            padding-right: 0;
+        }
+    }
+    &__media {
+        flex: 0 0 auto;
+    }
+}

--- a/test/fixtures/lines-between-children.expected.css
+++ b/test/fixtures/lines-between-children.expected.css
@@ -1,0 +1,31 @@
+.platform-organize {
+    background-image: linear-gradient(-45deg, #ff83b2 0%, #da82d8 49%, #b480ff 100%);
+
+    &__row {
+        display: flex;
+
+        &:nth-child(2) {
+            flex-direction: row-reverse;
+        }
+
+
+        &:nth-child(3) {
+            &:hover {
+                margin-bottom: 50px;
+            }
+        }
+    }
+
+
+    &__row:nth-child(3) &__text {
+        padding-right: 80px;
+        @media (--platform-organize--lap) {
+            padding-right: 0;
+        }
+    }
+
+
+    &__media {
+        flex: 0 0 auto;
+    }
+}

--- a/test/test.js
+++ b/test/test.js
@@ -189,3 +189,13 @@ test('Should sort prefixed propertyes as unprefixed if first one not in order, b
         'width'
     ] });
 });
+
+test('Should insert empty lines between children classes in accordance with option \'empty-lines-between-children-rules\'', t => {
+    return run(t, 'lines-between-children', {
+        'sort-order': [
+            ['...'],
+            ['>child']
+        ],
+        'empty-lines-between-children-rules': 2
+    });
+});


### PR DESCRIPTION
It would be cool keep indentation between ">child" classes. Much more readable.
Also, I`ve had in mind a csscomb.js issue about this (https://github.com/csscomb/csscomb.js/issues/441).