### PR TITLE
add option `smart-group-indent`

### DIFF
--- a/index.js
+++ b/index.js
@@ -198,6 +198,8 @@ function getApplicableNode(node) {
 module.exports = postcss.plugin('postcss-sorting', function (opts) {
     // Verify options and use defaults if not specified
     opts = verifyOptions(opts);
+    // Move to verifyOptions
+    var smartGroupIndentation = !!(opts || {})['smart-group-indent'] || false;
 
     return function (css) {
         var order = getSortOrderFromOptions(opts);
@@ -268,7 +270,16 @@ module.exports = postcss.plugin('postcss-sorting', function (opts) {
                     var prevNode = node.prev();
 
                     if (prevNode && node.raws.before) {
-                        if (node.groupIndex > prevNode.groupIndex) {
+                        var nextNode = node.next();
+                        var preventLineBreaking = smartGroupIndentation &&
+                            node.type !== 'rule' &&
+                            prevNode.type !== 'rule' &&
+                            node.groupIndex > prevNode.groupIndex &&
+                            prevNode.propertyIndex === 0 &&
+                            nextNode &&
+                            nextNode.groupIndex !== node.groupIndex;
+
+                        if (node.groupIndex > prevNode.groupIndex && !preventLineBreaking) {
                             node.raws.before = createLineBreaks(1) + node.raws.before;
                         }
 

--- a/test/fixtures/smart-group-indent.css
+++ b/test/fixtures/smart-group-indent.css
@@ -1,0 +1,30 @@
+div {
+    position: absolute;
+    top: 10px;
+    left: 20px;
+    display: inline-block;
+    font-size: 1.2em;
+}
+
+div {
+    display: inline-block;
+
+
+    span {
+        position: absolute;
+        top: 10px;
+
+
+
+        left: 20px;
+
+
+        display: inline-block;
+
+
+        font-size: 1.2em;
+    }
+
+    font-size: 1.2em;
+    position: absolute;
+}

--- a/test/fixtures/smart-group-indent.css
+++ b/test/fixtures/smart-group-indent.css
@@ -7,7 +7,7 @@ div {
 }
 
 div {
-    display: inline-block;
+    display: inline-block; /* comment */
 
 
     span {
@@ -27,4 +27,23 @@ div {
 
     font-size: 1.2em;
     position: absolute;
+}
+
+div {
+    position: absolute;
+    top: 10px;
+    display: inline-block;
+    font-size: 1.2em;
+}
+
+div {
+
+    /* position property double block comment */
+    /* position property double block comment */
+    position: absolute;
+    top: 10px;
+    /* display property block comment */
+    display: inline-block;
+
+    font-size: 1.2em;
 }

--- a/test/fixtures/smart-group-indent.expected.css
+++ b/test/fixtures/smart-group-indent.expected.css
@@ -9,7 +9,8 @@ div {
 }
 
 div {
-    display: inline-block;
+    display: inline-block; /* comment */
+
     position: absolute;
     font-size: 1.2em;
 
@@ -22,4 +23,23 @@ div {
 
         font-size: 1.2em;
     }
+}
+
+div {
+    display: inline-block;
+    position: absolute;
+    top: 10px;
+    font-size: 1.2em;
+}
+
+div {
+    /* display property block comment */
+    display: inline-block;
+
+    /* position property double block comment */
+    /* position property double block comment */
+    position: absolute;
+
+    top: 10px;
+    font-size: 1.2em;
 }

--- a/test/fixtures/smart-group-indent.expected.css
+++ b/test/fixtures/smart-group-indent.expected.css
@@ -1,0 +1,25 @@
+div {
+    display: inline-block;
+    position: absolute;
+
+    top: 10px;
+    left: 20px;
+
+    font-size: 1.2em;
+}
+
+div {
+    display: inline-block;
+    position: absolute;
+    font-size: 1.2em;
+
+    span {
+        display: inline-block;
+        position: absolute;
+
+        top: 10px;
+        left: 20px;
+
+        font-size: 1.2em;
+    }
+}

--- a/test/test.js
+++ b/test/test.js
@@ -219,3 +219,17 @@ test('Should insert empty lines between children classes in accordance with opti
 // test('Should sort LESS files', t => {
 //     return run(t, 'less.less', {}, 'less');
 // });
+
+test('Should collapse lines between one lines group rules with \`smart-group-indent\` option', t => {
+    return run(t, 'smart-group-indent', {
+        'sort-order': [
+            ['display'],
+            ['position'],
+            ['...'],
+            ['font-size'],
+            ['>child']
+        ],
+        'empty-lines-between-children-rules': 1,
+        'smart-group-indent': true
+    });
+});

--- a/test/test.js
+++ b/test/test.js
@@ -220,7 +220,7 @@ test('Should insert empty lines between children classes in accordance with opti
 //     return run(t, 'less.less', {}, 'less');
 // });
 
-test('Should collapse lines between one lines group rules with \`smart-group-indent\` option', t => {
+test('Should collapse lines between one properties group rules with \`group-single-declarations\` option', t => {
     return run(t, 'smart-group-indent', {
         'sort-order': [
             ['display'],
@@ -230,6 +230,6 @@ test('Should collapse lines between one lines group rules with \`smart-group-ind
             ['>child']
         ],
         'empty-lines-between-children-rules': 1,
-        'smart-group-indent': true
+        'group-single-declarations': true
     });
 });


### PR DESCRIPTION
This option purpose to prevent adding empty lines between single rule groups.
It`s just look awful when a small neat three lines css-rule becomes the five lines one.

`{'sort-order': [ ['display'], ['position'], ['font-size'] ], 'smart-group-indent': true}`

``` css
/* before */
div {
    display: inline-block;

    position: absolute;

    font-size: 1.2em;
}

/* after */
div {
    display: inline-block;
    position: absolute;
    font-size: 1.2em;
}
```
