### PR TITLE
Try to match the segment before the hyphen when the property is not specified

### DIFF
--- a/__tests__/fixtures/prehyphen-segment-order.css
+++ b/__tests__/fixtures/prehyphen-segment-order.css
@@ -1,0 +1,6 @@
+body {
+  color: #fff;
+  background-color: #000;
+  background-image: #000;
+  border-color: #f00;
+}

--- a/__tests__/fixtures/prehyphen-segment-order.expected.css
+++ b/__tests__/fixtures/prehyphen-segment-order.expected.css
@@ -1,0 +1,6 @@
+body {
+  border-color: #f00;
+  background-color: #000;
+  background-image: #000;
+  color: #fff;
+}

--- a/__tests__/properties-order.js
+++ b/__tests__/properties-order.js
@@ -280,3 +280,20 @@ test(
 		}
 	)
 );
+
+test(
+	`Should look for the matching segment before the hyphen when the property is not specified`,
+	() => runTest('prehyphen-segment-order',
+		{
+			'properties-order': [
+				{
+					properties: [
+						'border',
+						'background',
+						'color',
+					],
+				},
+			],
+		}
+	)
+);

--- a/lib/getPropertiesOrderData.js
+++ b/lib/getPropertiesOrderData.js
@@ -1,5 +1,16 @@
 'use strict';
 
 module.exports = function getPropertiesOrderData(expectedOrder, propName) {
-	return expectedOrder[propName];
+	let orderData = expectedOrder[propName];
+	// If prop was not specified but has a hyphen
+	// (e.g. `padding-top`), try looking for the segment preceding the hyphen
+	// and use that index
+
+	if (!orderData && propName.lastIndexOf('-') !== -1) {
+		const propNamePreHyphen = propName.slice(0, propName.lastIndexOf('-'));
+
+		orderData = getPropertiesOrderData(expectedOrder, propNamePreHyphen);
+	}
+
+	return orderData;
 };


### PR DESCRIPTION
With this change, the sorting algorithm works the same way as stylelint-order when
dealing with properties not specified in the config, but that has a "root" property specified.
E.g.:

```js
properties: [ 'border', 'padding' ]
```

Will sort this:

```css
a {
  padding-top: 10px;
  border-color: #f00;
}
```

To:

```css
a {
  border-color: #f00;
  padding-top: 10px;
}
```