### PR TITLE
Fixed typo in Config for `3.x` JSON in ReadMe

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Config for `3.x`:
 {
 	"properties-order": [
 		"margin",
-		"padding"
+		"padding",
 		"border",
 		"background"
 	]


### PR DESCRIPTION
Config for 3.x: json property number padding didn't have had comma which causes an error.