### PR TITLE
Fixed typo in CLI usage instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,13 @@ grunt.initConfig({
 });
 ```
 
-### CLI (via [postcss-cli](https://github.com/postcss/postcss-cli))
+### Command Line
+
+Add [postcss-cli]((https://github.com/postcss/postcss-cli))) and PostCSS Sorting to your project:
+
+```bash
+npm install postcss-cli postcss-sorting --save-dev
+```
 
 Create an appropriate `postcss.config.js` like this example:
 

--- a/README.md
+++ b/README.md
@@ -142,6 +142,38 @@ grunt.initConfig({
 });
 ```
 
+### CLI (via [postcss-cli](https://github.com/postcss/postcss-cli))
+
+Create an appropriate `postcss.config.js` like this example:
+
+```js
+module.exports = (ctx) => ({
+  plugins: {
+    'postcss-sorting': {
+      'order': [
+        'custom-properties',
+        'dollar-variables',
+        'declarations',
+        'at-rules',
+        'rules'
+      ],
+
+      'properties-order': 'alphabetical',
+
+      'unspecified-properties-position': 'bottom'
+    }
+  }
+})
+```
+
+Or, simply add the `'postcss-sorting'` section to your existing postcss-cli configuration file. Next, execute:
+
+```bash
+postcss -c postcss.config.js  --no-map -r your_css_file.css
+```
+
+For more information and options, please consult the [postcss-cli docs](https://github.com/postcss/postcss-cli/blob/master/README.md).
+
 ## Related tools
 
 [stylelint] and [stylelint-order] help lint style sheets and let you know if style sheet order is correct. Also, they could autofix style sheets.

--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ grunt.initConfig({
 
 ### Command Line
 
-Add [postcss-cli]((https://github.com/postcss/postcss-cli))) and PostCSS Sorting to your project:
+Add [postcss-cli](https://github.com/postcss/postcss-cli) and PostCSS Sorting to your project:
 
 ```bash
 npm install postcss-cli postcss-sorting --save-dev


### PR DESCRIPTION
Sorry, I introduced a typo in the link to postcss-cli. This PR fixes that.