### PR TITLE
Adds at-rule excludes for rules that can't be safely moved

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,8 +43,8 @@ a {
 ```
 
 ## Ignored at-rules
-Some at-rules, like [control](http://sass-lang.com/documentation/file.SASS_REFERENCE.html#control_directives__expressions) and [function](http://sass-lang.com/documentation/file.SASS_REFERENCE.html#function_directives) directives in Sass, are ignored. It means rules won't touch content inside these at-rules, as doing so could change or break functionality.
 
+Some at-rules, like [control](http://sass-lang.com/documentation/file.SASS_REFERENCE.html#control_directives__expressions) and [function](http://sass-lang.com/documentation/file.SASS_REFERENCE.html#function_directives) directives in Sass, are ignored. It means rules won't touch content inside these at-rules, as doing so could change or break functionality.
 
 ## Migration from `2.x`
 

--- a/README.md
+++ b/README.md
@@ -42,6 +42,10 @@ a {
 }
 ```
 
+## Ignored at-rules
+Some at-rules, like [control](http://sass-lang.com/documentation/file.SASS_REFERENCE.html#control_directives__expressions) and [function](http://sass-lang.com/documentation/file.SASS_REFERENCE.html#function_directives) directives in Sass, are ignored. It means rules won't touch content inside these at-rules, as doing so could change or break functionality.
+
+
 ## Migration from `2.x`
 
 Remove all `*-empty-line-before` and `clean-empty-lines` options. Use [stylelint] with `--fix` option instead.

--- a/lib/isRuleWithNodes.js
+++ b/lib/isRuleWithNodes.js
@@ -1,5 +1,12 @@
 'use strict';
 
+const atRuleExcludes = ['function', 'if', 'else', 'for', 'each', 'while'];
+
 module.exports = function isRuleWithNodes(node) {
-	return (node.type === 'rule' || node.type === 'atrule') && node.nodes && node.nodes.length;
+	return (
+		(node.type === 'rule' || node.type === 'atrule') &&
+		node.nodes &&
+		node.nodes.length &&
+		atRuleExcludes.indexOf(node.name) === -1
+	);
 };

--- a/lib/order/__tests__/order.js
+++ b/lib/order/__tests__/order.js
@@ -538,6 +538,33 @@ groupTest([
 					}
 				`,
 			},
+			{
+				description: `doesn't change`,
+				fixture: `
+					@function testFunction($someCase, $value1, $value2) {
+						$result: 'default-value';
+						@if(typeof($someCase) == number) {
+							$result: append($result, '--v1');
+						} @else {
+							$result: append($result, '--v2');
+						}
+
+						@return $result;
+					}
+				`,
+				expected: `
+					@function testFunction($someCase, $value1, $value2) {
+						$result: 'default-value';
+						@if(typeof($someCase) == number) {
+							$result: append($result, '--v1');
+						} @else {
+							$result: append($result, '--v2');
+						}
+
+						@return $result;
+					}
+				`,
+			},
 		],
 	},
 ]);

--- a/lib/order/__tests__/order.js
+++ b/lib/order/__tests__/order.js
@@ -565,6 +565,35 @@ groupTest([
 					}
 				`,
 			},
+			{
+				description: `moves orderable mixin and groups properties, but does not not move @if to top`,
+				fixture: `
+					div {
+						display: block;
+						@orderableMixin;
+
+						@if (typeof($someCase) == number) {
+							display: none;
+						} @else {
+							color: blue;
+						}
+						color: red;
+					}
+				`,
+				expected: `
+					div {
+						@orderableMixin;
+						display: block;
+						color: red;
+
+						@if (typeof($someCase) == number) {
+							display: none;
+						} @else {
+							color: blue;
+						}
+					}
+				`,
+			},
 		],
 	},
 ]);

--- a/lib/order/index.js
+++ b/lib/order/index.js
@@ -6,14 +6,12 @@ const processLastComments = require('../processLastComments');
 const processMostNodes = require('../processMostNodes');
 const sorting = require('../sorting');
 
-const AT_RULE_EXCLUDES = ['function', 'if', 'else', 'for', 'each', 'while'];
-
 module.exports = function(css, opts) {
 	const expectedOrder = createExpectedOrder(opts.order);
 
 	css.walk(function(node) {
 		// Process only rules and atrules with nodes
-		if (isRuleWithNodes(node) && AT_RULE_EXCLUDES.indexOf(node.name) === -1) {
+		if (isRuleWithNodes(node)) {
 			// Nodes for sorting
 			let processed = [];
 

--- a/lib/order/index.js
+++ b/lib/order/index.js
@@ -6,12 +6,14 @@ const processLastComments = require('../processLastComments');
 const processMostNodes = require('../processMostNodes');
 const sorting = require('../sorting');
 
+const AT_RULE_EXCLUDES = ['function', 'if', 'else', 'for', 'each', 'while'];
+
 module.exports = function(css, opts) {
 	const expectedOrder = createExpectedOrder(opts.order);
 
 	css.walk(function(node) {
 		// Process only rules and atrules with nodes
-		if (isRuleWithNodes(node)) {
+		if (isRuleWithNodes(node) && AT_RULE_EXCLUDES.indexOf(node.name) === -1) {
 			// Nodes for sorting
 			let processed = [];
 


### PR DESCRIPTION
Hello!

As mentioned in #64, there are some at-rules that cannot be safely moved as part of the sorting process. I have run into this issue with `@function`. In that case, the `@return` statement can be moved in such a way that the function no longer works as expected. The reporter of #64 ran into it with control directives.

This change creates an array of excluded `at-rules` and filters those rules out of the sorting process. Tests all pass and I created one new test for the `@function` case. Let me know what you think!

fixes #64 