### PR TITLE
Update shorthandData.js

### DIFF
--- a/lib/properties-order/shorthandData.js
+++ b/lib/properties-order/shorthandData.js
@@ -3,7 +3,11 @@
 // See https://github.com/stylelint/stylelint/blob/10.1.0/lib/reference/shorthandData.js
 module.exports = {
 	margin: ['margin-top', 'margin-bottom', 'margin-left', 'margin-right'],
+	'margin-block': ['margin-block-start', 'margin-block-end'],
+	'margin-inline': ['margin-inline-start', 'margin-inline-end'],
 	padding: ['padding-top', 'padding-bottom', 'padding-left', 'padding-right'],
+	'padding-block': ['padding-block-start', 'padding-block-end'],
+	'padding-inline': ['padding-inline-start', 'padding-inline-end'],
 	background: [
 		'background-image',
 		'background-size',
@@ -128,7 +132,9 @@ module.exports = {
 	'grid-gap': ['grid-row-gap', 'grid-column-gap'],
 	'grid-row': ['grid-row-start', 'grid-row-end'],
 	'grid-template': ['grid-template-columns', 'grid-template-rows', 'grid-template-areas'],
+	offset: ['offset-anchor', 'offset-distance', 'offset-path', 'offset-position', 'offset-rotate'],
 	outline: ['outline-color', 'outline-style', 'outline-width'],
+	overflow: ['overflow-x', 'overflow-y'],
 	'text-decoration': ['text-decoration-color', 'text-decoration-style', 'text-decoration-line'],
 	'text-emphasis': ['text-emphasis-style', 'text-emphasis-color'],
 	mask: [
@@ -141,4 +147,12 @@ module.exports = {
 		'mask-clip',
 		'mask-composite',
 	],
+	'mask-border': [
+		'mask-border-mode',
+		'mask-border-outset',
+		'mask-border-repeat',
+		'mask-border-slice',
+		'mask-border-source',
+		'mask-border-width'
+	]
 };


### PR DESCRIPTION
Added some missing short hands ([Constituent properties](https://developer.mozilla.org/en-US/docs/Web/CSS/view-timeline#constituent_properties)):
- [margin-block](https://developer.mozilla.org/en-US/docs/Web/CSS/margin-block)
- [margin-inline](https://developer.mozilla.org/en-US/docs/Web/CSS/margin-inline)
- [padding-block](https://developer.mozilla.org/en-US/docs/Web/CSS/padding-block)
- [padding-inline](https://developer.mozilla.org/en-US/docs/Web/CSS/padding-inline)
- [offset](https://developer.mozilla.org/en-US/docs/Web/CSS/offset)
- [overflow](https://developer.mozilla.org/en-US/docs/Web/CSS/overflow)
- [mask-border](https://developer.mozilla.org/en-US/docs/Web/CSS/mask-border)